### PR TITLE
fix(auth): route MFA challenge responses to OTP flow

### DIFF
--- a/app/frontend/hadiasaas-web/src/auth.ts
+++ b/app/frontend/hadiasaas-web/src/auth.ts
@@ -146,6 +146,10 @@ export const authOptions: NextAuthOptions = {
             { baseURL: apiBaseUrl }
           )) as LoginResponse
 
+          if (result.challengeId) {
+            throw new Error(`MFA_REQUIRED:${result.challengeId}`)
+          }
+
           if (!result.accessToken || !result.refreshToken) {
             return null
           }


### PR DESCRIPTION
### Motivation
- Ensure responses from the authentication API that include a `challengeId` (MFA challenge) but do not include a token pair are treated as MFA-required so the sign-in UI can redirect users into the OTP flow instead of surfacing a generic invalid-credentials error.

### Description
- Add an explicit check in the NextAuth Credentials `authorize` flow in `app/frontend/hadiasaas-web/src/auth.ts` to throw `MFA_REQUIRED:<challengeId>` when `result.challengeId` is present, before validating presence of `accessToken`/`refreshToken`.

### Testing
- Ran `pnpm --filter hadiasaas-webapp lint` which completed successfully with 7 pre-existing ESLint warnings and no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae68ea4d308323b79c334297aee6a6)